### PR TITLE
Update containers.json

### DIFF
--- a/lib/containers.json
+++ b/lib/containers.json
@@ -1104,7 +1104,6 @@
                 "h263p",
                 "h264",
                 "hap",
-                "hevc",
                 "hnm4video",
                 "hq_hqa",
                 "hqx",


### PR DESCRIPTION
HEVC is not a supported codec for the .avi container. File reflects that change.